### PR TITLE
🔒 Fix Command Injection in PDF page image extraction

### DIFF
--- a/lib/audiobook/image.rb
+++ b/lib/audiobook/image.rb
@@ -47,20 +47,20 @@ module Audiobook
         tmp_png = "#{base}.png"
 
         # 1) pdftoppm
-        system("pdftoppm -f #{page_num} -l #{page_num} -png -singlefile '#{pdf_path}' '#{base}'")
+        Sh.run "pdftoppm -f #{page_num} -l #{page_num} -png -singlefile #{Sh.escape(pdf_path)} #{Sh.escape(base)}"
 
         unless File.exist?(tmp_png)
           # 2) pdfimages
-          system("pdfimages -png -f #{page_num} -l #{page_num} '#{pdf_path}' '#{base}'")
+          Sh.run "pdfimages -png -f #{page_num} -l #{page_num} #{Sh.escape(pdf_path)} #{Sh.escape(base)}"
           candidate = Dir["#{base}*.png"].min
           FileUtils.mv(candidate, tmp_png) if candidate
         end
 
         unless File.exist?(tmp_png)
           # 3) Ghostscript
-          system("gs -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pngalpha -r200 " \
+          Sh.run "gs -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pngalpha -r200 " \
                  "-dFirstPage=#{page_num} -dLastPage=#{page_num} " \
-                 "-sOutputFile='#{tmp_png}' '#{pdf_path}' 2>&1 >/dev/null")
+                 "-sOutputFile=#{Sh.escape(tmp_png)} #{Sh.escape(pdf_path)}"
         end
 
         if File.exist?(tmp_png)


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Command injection in `lib/audiobook/image.rb` during PDF page image extraction.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could craft a PDF filename containing shell special characters (e.g., `' ; touch /tmp/exploited ; '`) to execute arbitrary commands on the system when the image extraction process is triggered.

### 🛡️ Solution: How the fix addresses the vulnerability
The manual single-quoting of paths in `system` calls was replaced with `Sh.run` and proper argument escaping using `Sh.escape`. This ensures that all shell-sensitive characters are correctly handled and cannot be used to break out of the intended command context.


---
*PR created automatically by Jules for task [8833826186204825607](https://jules.google.com/task/8833826186204825607) started by @brauliobo*