### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in PDF and Image processing

### DIFF
--- a/lib/audiobook/book.rb
+++ b/lib/audiobook/book.rb
@@ -17,6 +17,7 @@ require_relative 'heading'
 require_relative 'image'
 require_relative 'page'
 require_relative '../translator'
+require_relative '../utils/sh'
 
 module Audiobook
   # Represents an intermediate structured manuscript that can be saved as YAML.
@@ -235,7 +236,7 @@ module Audiobook
 
       tmp_base = File.join(dir, "#{base}-thumb")
       tmp_thumb = "#{tmp_base}.png"
-      return nil unless system("pdftoppm -f #{page_num} -l #{page_num} -png -singlefile '#{pdf_path}' '#{tmp_base}'")
+      return nil unless system("pdftoppm", "-f", page_num.to_s, "-l", page_num.to_s, "-png", "-singlefile", pdf_path, tmp_base)
 
       candidate = Dir["#{tmp_base}*.png"].min
       return nil unless candidate

--- a/lib/audiobook/image.rb
+++ b/lib/audiobook/image.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'tmpdir'
 require_relative 'paragraph'
 require_relative '../ocr'
+require_relative '../utils/sh'
 
 module Audiobook
   # Represents an image that needs OCR, then generates audio like a paragraph
@@ -47,20 +48,21 @@ module Audiobook
         tmp_png = "#{base}.png"
 
         # 1) pdftoppm
-        system("pdftoppm -f #{page_num} -l #{page_num} -png -singlefile '#{pdf_path}' '#{base}'")
+        system("pdftoppm", "-f", page_num.to_s, "-l", page_num.to_s, "-png", "-singlefile", pdf_path, base)
 
         unless File.exist?(tmp_png)
           # 2) pdfimages
-          system("pdfimages -png -f #{page_num} -l #{page_num} '#{pdf_path}' '#{base}'")
+          system("pdfimages", "-png", "-f", page_num.to_s, "-l", page_num.to_s, pdf_path, base)
           candidate = Dir["#{base}*.png"].min
           FileUtils.mv(candidate, tmp_png) if candidate
         end
 
         unless File.exist?(tmp_png)
           # 3) Ghostscript
-          system("gs -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pngalpha -r200 " \
-                 "-dFirstPage=#{page_num} -dLastPage=#{page_num} " \
-                 "-sOutputFile='#{tmp_png}' '#{pdf_path}' 2>&1 >/dev/null")
+          system("gs", "-dSAFER", "-dBATCH", "-dNOPAUSE", "-sDEVICE=pngalpha", "-r200",
+                 "-dFirstPage=#{page_num}", "-dLastPage=#{page_num}",
+                 "-sOutputFile=#{tmp_png}", pdf_path,
+                 out: File::NULL, err: [:child, :out])
         end
 
         if File.exist?(tmp_png)

--- a/lib/audiobook/parsers/pdf.rb
+++ b/lib/audiobook/parsers/pdf.rb
@@ -122,8 +122,9 @@ module Audiobook
         end
 
         if page_lines.empty?
-          cmd = "pdftotext -enc UTF-8 -layout -f #{page_num} -l #{page_num} '#{pdf_path}' - 2>/dev/null"
-          `#{cmd}`.to_s.split(/\r?\n+/).each { |l| add_line.call(l) }
+          require 'open3'
+          output, _status = Open3.capture2e("pdftotext", "-enc", "UTF-8", "-layout", "-f", page_num.to_s, "-l", page_num.to_s, pdf_path, "-")
+          output.to_s.split(/\r?\n+/).each { |l| add_line.call(l) }
         end
 
         # Calculate spacing between lines and add x_position
@@ -151,8 +152,8 @@ module Audiobook
         # Detect if page has images using pdfimages tool (more reliable)
         has_images = begin
           # Check if pdfimages can list images for this page
-          cmd = "pdfimages -f #{page_num} -l #{page_num} -list #{Sh.escape(pdf_path)} 2>/dev/null"
-          output = `#{cmd}`
+          require 'open3'
+          output, _status = Open3.capture2e("pdfimages", "-f", page_num.to_s, "-l", page_num.to_s, "-list", pdf_path)
           # pdfimages outputs header lines, then image lines starting with spaces+digits+"image"
           # Skip header lines (starting with "page" or dashes) and check for image lines
           output.lines.any? { |line| line.match?(/^\s+\d+\s+\d+\s+image/i) }

--- a/lib/audiobook/parsers/puppeteer_base.rb
+++ b/lib/audiobook/parsers/puppeteer_base.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'digest'
 require 'puppeteer'
 require_relative 'base'
+require_relative '../../utils/sh'
 
 module Audiobook
   module Parsers
@@ -54,11 +55,9 @@ module Audiobook
         sorted = images.sort
         # Prefer img2pdf when available; fallback to ImageMagick convert
         if system('which img2pdf >/dev/null 2>&1')
-          args = sorted.map { |p| "'#{p}'" }.join(' ')
-          system("img2pdf #{args} -o '#{out_pdf}'")
+          system("img2pdf", *sorted, "-o", out_pdf)
         else
-          args = sorted.map { |p| "'#{p}'" }.join(' ')
-          system("convert #{args} '#{out_pdf}'")
+          system("convert", *sorted, out_pdf)
         end
         out_pdf
       end

--- a/lib/audiobook/text_pdf.rb
+++ b/lib/audiobook/text_pdf.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require_relative 'book'
+require_relative '../utils/sh'
 
 module Audiobook
   class TextPdf
@@ -134,13 +135,11 @@ module Audiobook
     end
 
     def wkhtmltopdf_convert(html_path, pdf_path)
-      cmd = "wkhtmltopdf --page-size A4 --margin-top 20mm --margin-bottom 20mm --margin-left 20mm --margin-right 20mm '#{html_path}' '#{pdf_path}'"
-      system(cmd) || raise('wkhtmltopdf conversion failed')
+      system("wkhtmltopdf", "--page-size", "A4", "--margin-top", "20mm", "--margin-bottom", "20mm", "--margin-left", "20mm", "--margin-right", "20mm", html_path, pdf_path) || raise('wkhtmltopdf conversion failed')
     end
 
     def pandoc_convert(html_path, pdf_path)
-      cmd = "pandoc -f html -t pdf -o '#{pdf_path}' '#{html_path}'"
-      system(cmd) || raise('pandoc conversion failed')
+      system("pandoc", "-f", "html", "-t", "pdf", "-o", pdf_path, html_path) || raise('pandoc conversion failed')
     end
   end
 end


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in PDF and Image processing

🚨 Severity: CRITICAL
💡 Vulnerability: Command injection vulnerabilities were present due to string interpolation of unsanitized file paths (e.g., `pdf_path`) in shell commands executed via `system` or backticks (`` ` ``).
🎯 Impact: A maliciously crafted filename could break out of the shell command and execute arbitrary code on the host machine.
🔧 Fix: Refactored system calls to use Ruby's multi-argument array format for `system()` and `Open3.capture2e()`, which natively bypasses the shell and inherently prevents command injection. 
✅ Verification: Review the updated files (`image.rb`, `puppeteer_base.rb`, `book.rb`, `text_pdf.rb`, `pdf.rb`) to verify that the array form of `system` and `Open3` is used instead of string interpolation with `system()` or backticks.

---
*PR created automatically by Jules for task [13711935853294520704](https://jules.google.com/task/13711935853294520704) started by @brauliobo*