### PR TITLE
🧹 [code health improvement] remove duplicate faraday requirement

### DIFF
--- a/lib/boot.rb
+++ b/lib/boot.rb
@@ -11,7 +11,6 @@ end
 require 'active_support/all'
 require 'json'
 require 'faraday'
-require 'faraday'
 require 'faraday/multipart'
 require 'rack/mime'
 


### PR DESCRIPTION
🎯 **What:** Removed a duplicate `require 'faraday'` line in `lib/boot.rb`.
💡 **Why:** Duplicate requires are unnecessary and clutter the code. Removing the duplicate improves maintainability and readability without affecting functionality, as Ruby's `require` is idempotent.
✅ **Verification:**
- Verified with `read_file` that the duplicate line was removed and the file structure remains sound.
- Confirmed syntax is valid using `ruby -c lib/boot.rb`.
- Verified only one occurrence of `require 'faraday'` remains using `grep`.
- Attempted to run the full test suite; while execution was blocked by environmental constraints (Ruby version mismatch and missing dependencies), the change itself is trivial and safe.
✨ **Result:** Cleaner and more maintainable code in `lib/boot.rb`.

---
*PR created automatically by Jules for task [2128241113306868366](https://jules.google.com/task/2128241113306868366) started by @brauliobo*